### PR TITLE
added 'git' and 'curl' to precise64 box (issue #2)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     echo 'deb http://debian.datastax.com/community stable main' | tee -a /etc/apt/sources.list.d/cassandra.sources.list
     curl -L http://debian.datastax.com/debian/repo_key | apt-key add -
     sudo apt-get update
-    sudo apt-get install make unzip netcat lua5.1 openssl libpcre3 dnsmasq openjdk-7-jdk cassandra=$CASSANDRA_VERSION -y --force-yes
+    sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq openjdk-7-jdk cassandra=$CASSANDRA_VERSION -y --force-yes
     echo 'nameserver 10.0.2.3' >> /etc/resolv.conf
     /etc/init.d/cassandra restart
 


### PR DESCRIPTION
This adds git to 'precise64' box. 

I've noticed the my other PR #3 will require vagrant 1.5+.
so i added this, as a more 'consevative' update.

it adds git and curl, i know curl is not required but it is really helpful to have.