### PR TITLE
add env var to control machine RAM (issue #6)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provider :virtualbox do |vb|
    vb.name = "vagrant_kong"
-   vb.memory = 2048
+   vb.memory = ENV['KONG_VB_MEM'] || 2048
   end
 
   config.vm.box = "precise64"


### PR DESCRIPTION
adds the ability to control machine RAM size without update Vagrant file.
for example:
start vm with 4G RAM
<pre>
KONG_PATH=/path/to/kong KONG_VB_MEM=4096 vagrant up
</pre>

if one does not set the 'KONG_VB_MEM' env var the default is 2048, as its today.
<pre>
KONG_PATH=/path/to/kong vagrant up
</pre>