### PR TITLE
improvements + Oracle Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,17 @@ $ KONG_PATH=/path/to/kong/clone/ vagrant up
 
 This will tell Vagrant to mount your local Kong repository under the guest's `/kong` folder.
 
-The startup process will install all the dependencies necessary for developing (including Cassandra). The kong source code is mounted at `/kong`. The host ports `8000` and `8001` will be forwarded to the Vagrant box.
+The startup process will install all the dependencies necessary for developing (including Cassandra). The Kong source code is mounted at `/kong`. The host ports `8000` and `8001` will be forwarded to the Vagrant box.
+
+### Environment Variables
+
+You can alter the behavior of the provision step by setting the following environment variables:
+
+| name            | description                                                               | default   |
+| --------------- | ------------------------------------------------------------------------- | --------- |
+| `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `../kong` |
+| `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `latest`  |
+
 
 ## Building and running Kong
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,18 +14,23 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "precise64"
   config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
-  config.vm.synced_folder ENV["KONG_PATH"], "/kong"
+  if ENV["KONG_PATH"]
+    source = ENV["KONG_PATH"]
+  else
+    source = "../kong"
+  end
+
+  config.vm.synced_folder source, "/kong"
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
 
   config.vm.provision "shell", inline: "
-    KONG_VERSION=0.4.1
     CASSANDRA_VERSION=2.1.8
 
     # Install Cassandra
     echo 'deb http://debian.datastax.com/community stable main' | tee -a /etc/apt/sources.list.d/cassandra.sources.list
-    curl -L http://debian.datastax.com/debian/repo_key | apt-key add -
+    wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | apt-key add -
     sudo apt-get update
     sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq openjdk-7-jdk cassandra=$CASSANDRA_VERSION -y --force-yes
     echo 'nameserver 10.0.2.3' >> /etc/resolv.conf
@@ -36,7 +41,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     rm -rf $OUT
     mkdir -p $OUT
     cd $TMP
-    wget https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
+    wget https://downloadkong.org/precise_all.deb
     dpkg -i kong-*.deb
   "
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,18 +6,16 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">= 1.4.3"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.provider :virtualbox do |vb|
-   vb.name = "vagrant_kong"
-   vb.memory = ENV['KONG_VB_MEM'] || 2048
-  end
-
-  config.vm.box = "precise64"
-  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
-
   if ENV["KONG_PATH"]
     source = ENV["KONG_PATH"]
   else
     source = "../kong"
+  end
+
+  if ENV['KONG_VB_MEM']
+    memory = ENV["KONG_VB_MEM"]
+  else
+    memory = 2048
   end
 
   if ENV["KONG_VERSION"]
@@ -25,6 +23,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   else
     version = "latest"
   end
+
+  config.vm.provider :virtualbox do |vb|
+   vb.name = "vagrant_kong"
+   vb.memory = memory
+  end
+
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
 
   config.vm.synced_folder source, "/kong"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,20 +28,29 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.provision "shell", inline: "
     CASSANDRA_VERSION=2.1.8
 
+    # Install Oracle Java
+    sudo mkdir -p /usr/lib/jvm
+    sudo wget -q -O /tmp/jre-linux-x64.tar.gz --no-cookies --no-check-certificate --header 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.tar.gz
+    sudo tar zxvf /tmp/jre-linux-x64.tar.gz -C /usr/lib/jvm
+    sudo update-alternatives --install '/usr/bin/java' 'java' '/usr/lib/jvm/jre1.8.0_60/bin/java' 1
+    sudo update-alternatives --set java /usr/lib/jvm/jre1.8.0_60/bin/java
+
     # Install Cassandra
     echo 'deb http://debian.datastax.com/community stable main' | tee -a /etc/apt/sources.list.d/cassandra.sources.list
     wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | apt-key add -
+
     sudo apt-get update
-    sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq openjdk-7-jdk cassandra=$CASSANDRA_VERSION -y --force-yes
+    sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq cassandra=$CASSANDRA_VERSION -y --force-yes
+
     echo 'nameserver 10.0.2.3' >> /etc/resolv.conf
     /etc/init.d/cassandra restart
 
     # Install latest Kong
     TMP=/tmp/build/tmp
-    rm -rf $OUT
-    mkdir -p $OUT
+    rm -rf $TMP
+    mkdir -p $TMP
     cd $TMP
-    wget https://downloadkong.org/precise_all.deb
-    dpkg -i kong-*.deb
+    wget -q http://downloadkong.org/precise_all.deb
+    dpkg -i precise_all.deb
   "
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,37 +20,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     source = "../kong"
   end
 
+  if ENV["KONG_VERSION"]
+    version = ENV["KONG_VERSION"]
+  else
+    version = "latest"
+  end
+
   config.vm.synced_folder source, "/kong"
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
 
-  config.vm.provision "shell", inline: "
-    CASSANDRA_VERSION=2.1.8
-
-    # Install Oracle Java
-    sudo mkdir -p /usr/lib/jvm
-    sudo wget -q -O /tmp/jre-linux-x64.tar.gz --no-cookies --no-check-certificate --header 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.tar.gz
-    sudo tar zxvf /tmp/jre-linux-x64.tar.gz -C /usr/lib/jvm
-    sudo update-alternatives --install '/usr/bin/java' 'java' '/usr/lib/jvm/jre1.8.0_60/bin/java' 1
-    sudo update-alternatives --set java /usr/lib/jvm/jre1.8.0_60/bin/java
-
-    # Install Cassandra
-    echo 'deb http://debian.datastax.com/community stable main' | tee -a /etc/apt/sources.list.d/cassandra.sources.list
-    wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | apt-key add -
-
-    sudo apt-get update
-    sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq cassandra=$CASSANDRA_VERSION -y --force-yes
-
-    echo 'nameserver 10.0.2.3' >> /etc/resolv.conf
-    /etc/init.d/cassandra restart
-
-    # Install latest Kong
-    TMP=/tmp/build/tmp
-    rm -rf $TMP
-    mkdir -p $TMP
-    cd $TMP
-    wget -q http://downloadkong.org/precise_all.deb
-    dpkg -i precise_all.deb
-  "
+  config.vm.provision "shell", path: "provision.sh", :args => version
 end

--- a/provision.sh
+++ b/provision.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+KONG_VERSION=$@
+CASSANDRA_VERSION=2.1.8
+
+echo "Installing Kong version: $KONG_VERSION"
+
+# Install Oracle Java
+sudo mkdir -p /usr/lib/jvm
+sudo wget -q -O /tmp/jre-linux-x64.tar.gz --no-cookies --no-check-certificate --header 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.tar.gz
+sudo tar zxvf /tmp/jre-linux-x64.tar.gz -C /usr/lib/jvm
+sudo update-alternatives --install '/usr/bin/java' 'java' '/usr/lib/jvm/jre1.8.0_60/bin/java' 1
+sudo update-alternatives --set java /usr/lib/jvm/jre1.8.0_60/bin/java
+
+# Install Cassandra
+echo 'deb http://debian.datastax.com/community stable main' | tee -a /etc/apt/sources.list.d/cassandra.sources.list
+wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | apt-key add -
+
+sudo apt-get update
+sudo apt-get install git curl make unzip netcat lua5.1 openssl libpcre3 dnsmasq cassandra=$CASSANDRA_VERSION -y --force-yes
+
+echo 'nameserver 10.0.2.3' >> /etc/resolv.conf
+/etc/init.d/cassandra restart
+
+# Install latest Kong
+TMP=/tmp/build/tmp
+rm -rf $TMP
+mkdir -p $TMP
+cd $TMP
+wget -q -O "precise_all.deb" "http://downloadkong.org/precise_all.deb?version=$KONG_VERSION"
+dpkg -i "precise_all.deb"
+
+echo "Successfully Installed Kong version: $KONG_VERSION"


### PR DESCRIPTION
- fix startup issues
  - set minimum required Vagrant version at `1.4.3`
  - use `wget` instead of `curl` (unavailable at the time) for grabbing datastax repo key
  - default value for soruce folder, prevents errors on calling `vagrant` without environment variable
  - use downloadkong.org to grab the latest released version automatically
  - fix unknown $OUT variable
- switch to Oracle Java 8 as recommended by Datastax
  - download and install Oracle Java 8.6_60