### PR TITLE
set ulimit value to 4096 (issue #9)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,5 +37,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
 
+  config.vm.provision "file", source: "conf/limits.conf", destination: "/tmp/limits.conf"
   config.vm.provision "shell", path: "provision.sh", :args => version
 end

--- a/conf/limits.conf
+++ b/conf/limits.conf
@@ -1,0 +1,57 @@
+# /etc/security/limits.conf
+#
+#Each line describes a limit for a user in the form:
+#
+#<domain>        <type>  <item>  <value>
+#
+#Where:
+#<domain> can be:
+#        - an user name
+#        - a group name, with @group syntax
+#        - the wildcard *, for default entry
+#        - the wildcard %, can be also used with %group syntax,
+#                 for maxlogin limit
+#        - NOTE: group and wildcard limits are not applied to root.
+#          To apply a limit to the root user, <domain> must be
+#          the literal username root.
+#
+#<type> can have the two values:
+#        - "soft" for enforcing the soft limits
+#        - "hard" for enforcing hard limits
+#
+#<item> can be one of the following:
+#        - core - limits the core file size (KB)
+#        - data - max data size (KB)
+#        - fsize - maximum filesize (KB)
+#        - memlock - max locked-in-memory address space (KB)
+#        - nofile - max number of open files
+#        - rss - max resident set size (KB)
+#        - stack - max stack size (KB)
+#        - cpu - max CPU time (MIN)
+#        - nproc - max number of processes
+#        - as - address space limit (KB)
+#        - maxlogins - max number of logins for this user
+#        - maxsyslogins - max number of logins on the system
+#        - priority - the priority to run user process with
+#        - locks - max number of file locks the user can hold
+#        - sigpending - max number of pending signals
+#        - msgqueue - max memory used by POSIX message queues (bytes)
+#        - nice - max nice priority allowed to raise to values: [-20, 19]
+#        - rtprio - max realtime priority
+#        - chroot - change root to directory (Debian-specific)
+#
+#<domain>      <type>  <item>         <value>
+#
+
+#*               soft    core            0
+#root            hard    core            100000
+#*               hard    rss             10000
+#@student        hard    nproc           20
+#@faculty        soft    nproc           20
+#@faculty        hard    nproc           50
+#ftp             hard    nproc           0
+#ftp             -       chroot          /ftp
+#@student        -       maxlogins       4
+
+* soft nofile 4096
+# End of file

--- a/provision.sh
+++ b/provision.sh
@@ -30,4 +30,8 @@ cd $TMP
 wget -q -O "precise_all.deb" "http://downloadkong.org/precise_all.deb?version=$KONG_VERSION"
 dpkg -i "precise_all.deb"
 
+# set ulimits
+sudo cp /tmp/limits.conf /etc/security/limits.conf
+rm -f /tmp/limits.conf
+
 echo "Successfully Installed Kong version: $KONG_VERSION"


### PR DESCRIPTION
set the value of ulimit to 4096.

to do that it upload a new */etc/security/limits.conf* which adds the following line:
<pre>
* soft nofile 4096
</pre>