### PR TITLE
Remove bad setup instruction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,6 @@ $ vagrant ssh
 # switch to the mounted Kong repo
 $ cd /kong
 
-# install Kong
-$ make dev
-
 # start Kong
 $ KONG_DATABASE=cassandra kong start
 ```


### PR DESCRIPTION
This instruction is not valid. There is no `Makefile` and Kong is already started. 