### PR TITLE
Add Cassandra installation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 [![][kong-logo]][website-url]
 
-Vagrant is used to create an isolated development environment for Kong including Postgres.
+Vagrant is used to create an isolated development environment for Kong 
+including Postgres.
 
 ## Starting the environment
 
@@ -27,13 +28,18 @@ $ cd kong-vagrant/
 $ KONG_PATH=/path/to/kong/clone/ vagrant up
 ```
 
-This will tell Vagrant to mount your local Kong repository under the guest's `/kong` folder.
+This will tell Vagrant to mount your local Kong repository under the guest's 
+`/kong` folder.
 
-The startup process will install all the dependencies necessary for developing (including Postgres). The Kong source code is mounted at `/kong`. The host ports `8000`, `8001` and `8443` will be forwarded to the Vagrant box.
+The startup process will install all the dependencies necessary for developing 
+(including Postgres, Cassandra and Redis). The Kong source code is mounted at 
+`/kong`. The host ports `8000`, `8001` and `8443` will be forwarded to the 
+Vagrant box.
 
 ### Environment Variables
 
-You can alter the behavior of the provision step by setting the following environment variables:
+You can alter the behavior of the provision step by setting the following 
+environment variables:
 
 | name            | description                                                               | default   |
 | --------------- | ------------------------------------------------------------------------- | --------- |
@@ -57,12 +63,13 @@ $ cd /kong
 $ make dev
 
 # start Kong
-$ kong start
+$ bin/kong start
 ```
 
 ## Testing Kong
 
-To verify Kong is running successfully, execute the following command from the host machine:
+To verify Kong is running successfully, execute the following command from the 
+host machine:
 
 ```shell
 $ curl http://localhost:8001
@@ -87,15 +94,20 @@ You should receive a JSON response:
 
 ## Coding
 
-The `lua_package_path` directive in the configuration specifies that the Lua code in your local folder will be used in favor of the system installation. The `lua_code_cache` directive being turned off, you can start Kong, edit your local files (on your host machine), and test your code without restarting Kong.
+The `lua_package_path` directive in the configuration specifies that the Lua 
+code in your local folder will be used in favor of the system installation. 
+The `lua_code_cache` directive being turned off, you can start Kong, edit your 
+local files (on your host machine), and test your code without restarting Kong.
 
-Eventually, familiarize yourself with the [Makefile Operations](https://github.com/Mashape/kong#makefile).
+Eventually, familiarize yourself with the 
+[Makefile Operations](https://github.com/Mashape/kong#makefile).
 
 ## Known Issues
 
 ### DNS failure
 
-If for some reason the Vagrant box doesn't resolve properly DNS names, please execute the following comand on the host:
+If for some reason the Vagrant box doesn't resolve properly DNS names, please 
+execute the following comand on the host:
 
 ```
 $ vagrant halt
@@ -110,10 +122,13 @@ $ vagrant up --provision
 
 ### Incompatible versions error
 
-When Kong starts it can give errors for incompatible versions. This happens for example when depedencies have been updated.
-eg. 0.9.2 required Openresty 1.9.15.1, whilst 0.9.5 requires 1.11.2.1. 
+When Kong starts it can give errors for incompatible versions. This happens for 
+example when depedencies have been updated. Eg. 0.9.2 required Openresty 
+1.9.15.1, whilst 0.9.5 requires 1.11.2.1. 
 
-So please reprovision it and specify the proper version you want to work with (either newer or older, see the defaults above), as in the example below with version 0.9.2;
+So please reprovision it and specify the proper version you want to work with 
+(either newer or older, see the defaults above), as in the example below with 
+version 0.9.2;
 
 ```shell
 # clone the Kong repo and switch explicitly to the 0.9.2 version.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_VERSION"]
     version = ENV["KONG_VERSION"]
   else
-    version = "0.9.7"
+    version = "0.9.8"
   end
 
   config.vm.provider :virtualbox do |vb|

--- a/provision.sh
+++ b/provision.sh
@@ -59,4 +59,26 @@ sudo bash -c "cat >> /etc/security/limits.conf" << EOL
 * hard     nofile         65535
 EOL
 
-echo "Successfully Installed Kong version: $KONG_VERSION"
+# Create a Cassandra setup script
+cat <<EOT >> /home/vagrant/cassandra2_setup.sh
+# Install java runtime
+echo Fetching and installing java...
+sudo mkdir -p /usr/lib/jvm
+sudo wget -q -O /tmp/jre-linux-x64.tar.gz --no-cookies --no-check-certificate --header 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.tar.gz
+sudo tar zxvf /tmp/jre-linux-x64.tar.gz -C /usr/lib/jvm
+sudo update-alternatives --install '/usr/bin/java' 'java' '/usr/lib/jvm/jre1.8.0_60/bin/java' 1
+sudo update-alternatives --set java /usr/lib/jvm/jre1.8.0_60/bin/java
+
+# install cassandra
+echo Fetching and installing Cassandra...
+echo 'deb http://debian.datastax.com/community stable main' | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
+wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | sudo apt-key add -
+sudo apt-get update
+sudo apt-get install cassandra=2.2.8 -y --force-yes
+sudo /etc/init.d/cassandra restart
+EOT
+
+chmod +x /home/vagrant/cassandra2_setup.sh
+
+echo "Successfully Installed Kong version: $KONG_VERSION, with Postgres."
+echo 'To setup Cassandra 2.x use the script at "~/cassandra2_setup.sh".'

--- a/provision.sh
+++ b/provision.sh
@@ -32,7 +32,8 @@ CREATE DATABASE kong_tests OWNER kong;
 EOF
 
 # Install Kong
-wget -O kong.deb https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
+echo Fetching and installing Kong...
+wget -q -O kong.deb https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
 sudo apt-get install -y netcat openssl libpcre3 dnsmasq procps perl
 sudo dpkg -i kong.deb
 rm kong.deb
@@ -65,9 +66,7 @@ sudo bash -c "cat >> /etc/security/limits.conf" << EOL
 * hard     nofile         65535
 EOL
 
-# Create a Cassandra setup script
-cat <<EOT >> /home/vagrant/cassandra2_setup.sh
-# Install java runtime
+# Install java runtime (Cassandra dependency)
 echo Fetching and installing java...
 sudo mkdir -p /usr/lib/jvm
 sudo wget -q -O /tmp/jre-linux-x64.tar.gz --no-cookies --no-check-certificate --header 'Cookie: gpw_e24=http%3A%2F%2Fwww.oracle.com%2F; oraclelicense=accept-securebackup-cookie' http://download.oracle.com/otn-pub/java/jdk/8u60-b27/jre-8u60-linux-x64.tar.gz
@@ -82,9 +81,5 @@ wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | sudo apt-key add 
 sudo apt-get update
 sudo apt-get install cassandra=2.2.8 -y --force-yes
 sudo /etc/init.d/cassandra restart
-EOT
 
-chmod +x /home/vagrant/cassandra2_setup.sh
-
-echo "Successfully Installed Kong version: $KONG_VERSION, with Postgres."
-echo 'To setup Cassandra 2.x use the script at "~/cassandra2_setup.sh".'
+echo "Successfully Installed Kong version: $KONG_VERSION"


### PR DESCRIPTION
Upon provisioning creates a script `~/cassandra2.sh` that will install Cassandra 2.x in the vagrant box.

This will ease the test setup for new (plugin) developers. 

Steps:
```
~/cassandra2.sh
cd /kong
make dev
make test-all
```
