### PR TITLE
Failed loading manifest error

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -49,6 +49,9 @@ export PATH=$PATH:/usr/local/bin:/usr/local/openresty/bin
 # Adjust PATH for future ssh
 echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin" >> /home/vagrant/.bashrc
 
+# Prepare path to lua librairies
+ln -sfn /usr/local /home/vagrant/.luarocks
+
 # Set higher ulimit
 sudo bash -c 'echo "fs.file-max = 65536" >> /etc/sysctl.conf'
 sudo sysctl -p


### PR DESCRIPTION
Little fix to prevent this error when I have a fresh install and trying to run "make dev"
```

vagrant@precise64:/kong$ make dev
Updating manifest for /usr/local/lib/luarocks/rocks
kong 0.9.7-0 is now built and installed in /usr/local (license: MIT)

Warning: Failed loading manifest for /home/vagrant/.luarocks/lib/luarocks/rocks: /home/vagrant/.luarocks/lib/luarocks/rocks/manifest: No such file or directory
busted already installed, skipping
Warning: Failed loading manifest for /home/vagrant/.luarocks/lib/luarocks/rocks: /home/vagrant/.luarocks/lib/luarocks/rocks/manifest: No such file or directory
luacheck already installed, skipping
Warning: Failed loading manifest for /home/vagrant/.luarocks/lib/luarocks/rocks: /home/vagrant/.luarocks/lib/luarocks/rocks/manifest: No such file or directory
lua-llthreads2 already installed, skipping
```