### PR TITLE
Fix README. kong-plugin is required to run the Vagrant box..

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ $ cd kong
 $ git checkout next
 $ cd ..
 
+# clone the Kong Plugin repo required to run the Vagrant box
+$ git clone https://github.com/Mashape/kong-plugin
+
 # clone this repository
 $ git clone https://github.com/Mashape/kong-vagrant
 $ cd kong-vagrant/


### PR DESCRIPTION
Unless you clone the kong-plugin repo you'll get this error:

> $ vagrant up
> Bringing machine 'default' up with 'virtualbox' provider...
> There are errors in the configuration of this machine. Please fix
> the following errors and try again:
> 
> vm:
> * The host path of the shared folder is missing: ../kong-plugin
