### PR TITLE
Optional repos, and cassandra 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
+# workdirectory
 .vagrant/
+
+# source code locations
+kong/
+kong-plugin/
+

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ $ bin/kong start
 ### Testing Kong and custom plugins
 
 To use the test helpers from the Kong repo, you must first setup the 
-development enviornment as mentioned above.
+development environment as mentioned above.
 
 To run test suites, you should first stop Kong, and clear any environment
 variables you've set to prevent them from interfering with the tests.
@@ -208,7 +208,7 @@ Eventually, to test Kong familiarize yourself with the
   the same location where the tests run. It is in the Kong tree, excluded from the
   git repo, and accessible from the host to check logs when coding.
 
-## Environment Variables
+## Environment variables and configuration
 
 You can alter the behavior of the provision step by setting the following 
 environment variables:
@@ -225,6 +225,35 @@ Use them when provisioning, e.g.:
 ```shell
 $ KONG_VERSION=0.9.5 vagrant up
 ```
+
+The `_PATH` variables are will take the value set, or the defaults, but the 
+defaults will only be taken if they actually exist. As such the defaults allow
+for 2 file structures, without any configuration.
+
+Structure where everything resides inside the `kong-vagrant` repo:
+```
+-some_dir
+  |-kong-vagrant
+     |-kong
+     |-kong-plugin
+```
+
+or if you prefer all repos on the same level:
+```
+-some_dir
+  |-kong-vagrant
+  |-kong
+  |-kong-plugin
+```
+
+
+The (non-configurable) exposed ports are;
+
+- `8000` proxy port
+- `8143` ssl proxy port
+- `8001` admin api
+
+These are mapped 1-on-1 between the host and guest.
 
 ## Known Issues
 

--- a/README.md
+++ b/README.md
@@ -7,76 +7,42 @@
 
 [![][kong-logo]][website-url]
 
-Vagrant is used to create an isolated development environment for Kong 
+Vagrant is used to create an isolated environment for Kong 
 including Postgres, Cassandra and Redis.
 
-## Starting the environment
-
-Once you have Vagrant installed, follow those steps:
-
-```shell
-# clone the Kong repo and switch to the next branch to use the latest, unrelease code
-$ git clone https://github.com/Mashape/kong
-$ cd kong
-$ git checkout next
-$ cd ..
-
-# clone this repository
-$ git clone https://github.com/Mashape/kong-vagrant
-$ cd kong-vagrant/
-
-# start a box with a folder synced to your local Kong clone
-$ vagrant up
-```
-
-This will tell Vagrant to mount your local Kong repository under the guest's 
-`/kong` folder.
-
-The startup process will install all the dependencies necessary for developing 
-(including Postgres, Cassandra and Redis). The Kong source code is mounted at 
-`/kong`. The host ports `8000`, `8001` and `8443` will be forwarded to the 
-Vagrant box.
-
-### Environment Variables
-
-You can alter the behavior of the provision step by setting the following 
-environment variables:
-
-| name            | description                                                               | default   |
-| --------------- | ------------------------------------------------------------------------- | --------- |
-| `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.10.0`  |
-| `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `1024`    |
-| `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
-| `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
-| `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |
-
-Use them when provisioning, e.g.:
-```shell
-$ KONG_VERSION=0.9.5 vagrant up
-```
-
-## Building and running Kong
-
-To build Kong execute the following commands:
-
-```shell
-# SSH into the vagrant box
-$ vagrant ssh
-
-# switch to the mounted Kong repo
-$ cd /kong
-
-# install Kong
-$ make dev
-
-# start Kong
-$ bin/kong start
-```
+You can use the vagrant box either as an all-in-one Kong installation for
+testing purposes, or you can link it up with source code and start developing
+on Kong or on custom plugins.
 
 ## Testing Kong
 
-To verify Kong is running successfully, execute the following command from the 
-host machine:
+If you just want to give Kong a test ride, and you have Vagrant installed, 
+then you can simply clone this vagrant repo, and build the vm.
+
+```shell
+# clone this repository
+$ git clone https://github.com/Mashape/kong-vagrant
+$ cd kong-vagrant
+
+# build the machine
+$ vagrant up
+
+# start Kong, by ssh into the vm
+$ vagrant ssh
+$ kong start
+
+# alternatively use ssh -c option to start Kong
+$ vagrant ssh -c "kong start"
+```
+
+Kong is now started and is available on the default ports;
+
+- `8000` proxy port
+- `8143` ssl proxy port
+- `8001` admin api
+
+To verify Kong is running successfully, execute the following command (from
+the host machine):
 
 ```shell
 $ curl http://localhost:8001
@@ -99,27 +65,45 @@ You should receive a JSON response:
 }
 ```
 
-## Developing plugins
+See the environments variables section below for defaults used and how to
+modify the settings of the Vagrant machine. 
 
-Clone the plugin template next to your clones of `kong` and `kong-vagrant`:
+## Development environment
+
+Once you have Vagrant installed, follow these steps to set up a development
+environment for both Kong itself as well as for custum plugins. It will
+install the development dependencies like the `busted` test framework.
 
 ```shell
-# clone the plugin template repository
+# clone this repository
+$ git clone https://github.com/Mashape/kong-vagrant
+$ cd kong-vagrant
+
+# clone the Kong repo (inside the vagrant one)
+$ git clone https://github.com/Mashape/kong
+
+# only if you want to develop a custom plugin, also clone the plugin template
 $ git clone https://github.com/Mashape/kong-plugin
-```
 
-Setup Kong to use the plugin:
-```shell
-# SSH into the vagrant box
+# build a box with a folder synced to your local Kong and plugin sources
+$ vagrant up
+
+# ssh into the Vagrant machine, and setup the dev environment
 $ vagrant ssh
+$ cd /kong
+$ make dev
 
-# tell Kong to load the custom plugin
+# only if you want to run the custom plugin, tell Kong to load it
 $ export KONG_CUSTOM_PLUGINS=myPlugin
 
-# start Kong
+# startup kong: while inside '/kong' call the start script from the repo!
 $ cd /kong
 $ bin/kong start
 ```
+
+This will tell Vagrant to mount your local Kong repository under the guest's 
+`/kong` folder, and (if you cloned it) the 'kong-plugin' repository under the
+guest's `/kong-plugin` folder.
 
 To verify Kong has loaded the plugin successfully, execute the following command 
 from the host machine:
@@ -133,7 +117,7 @@ to indicate the plugin was loaded.
 To start using the plugin, execute from the host:
 ```shell
 # create an api that simply echoes the request using mockbin, using a 
-# 'catch-all' setup with the request path set to '/'
+# 'catch-all' setup with the `uris` field set to '/'
 # NOTE: for pre-0.10 versions 'uris=' below should be 'request_path='
 $ curl -i -X POST \
   --url http://localhost:8001/apis/ \
@@ -154,30 +138,67 @@ $ curl -i http://localhost:8000
 The response you get should be an echo (by Mockbin) of the request. But in the
 response headers the plugin has now inserted a header `Bye-World`.
 
-## Testing plugins
+### Running Kong from the source repo
 
-The plugin tests can use the helpers that come with the Kong repo for testing.
-To execute the basic tests that come with the plugin execute:
+Because the start and stop scripts are in the repository, you must use those
+to stop and start kong. Using the scripts that came with the base version you
+specified when building the Vagrant box will lead to unpredictable results.
 
 ```shell
-# SSH into the vagrant box
+# ssh into the Vagrant machine
 $ vagrant ssh
 
-#enter the Kong repo
-cd /kong
+# only if you want to run the custom plugin, tell Kong to load it
+$ export KONG_CUSTOM_PLUGINS=myPlugin
 
-# if not done so already make a dev environment
-$ make dev
-
-# run the plugin tests from the Kong repo
-$ bin/busted /kong-plugin/spec
-
-# for more verbose output do
-$ bin/busted -v -o gtest /kong-plugin/spec
+# startup kong: while inside '/kong' call the start script from the repo!
+$ cd /kong
+$ bin/kong start
 ```
 
+### Testing Kong and custom plugins
 
-## Coding
+To use the test helpers from the Kong repo, you must first setup the 
+development enviornment as mentioned above.
+
+To run test suites, you should first stop Kong, and clear any environment
+variables you've set to prevent them from interfering with the tests.
+
+The test environment has the same limitation as running from source in that it
+must be executed from the Kong source repo at `/kong`, inside the Vagrant
+machine.
+
+```shell
+# ssh into the Vagrant machine
+$ vagrant ssh
+
+# testing: while inside '/kong' call `busted` from the repo!
+$ cd /kong
+$ bin/busted
+
+# or for more verbose output do
+$ bin/busted -v -o gtest
+```
+
+Note that Kong comes with a special Busted script that runs against the
+OpenResty environment, instead of regular busted which runs against Lua(JIT)
+directly.
+
+To test the plugin specific tests:
+```shell
+# ssh into the Vagrant machine
+$ vagrant ssh
+
+# testing: while inside '/kong' call `busted` from the repo, but specify
+# the plugin testsuite to be executed
+$ cd /kong
+$ bin/busted /kong-plugin/spec
+```
+
+Eventually, to test Kong familiarize yourself with the 
+[Makefile Operations](https://github.com/Mashape/kong#makefile).
+
+### Development tips and tricks
 
 - `export KONG_LUA_CODE_CACHE=false` turns the code caching off, you can start 
   Kong, edit your local files (on your host machine), and test your code without 
@@ -187,16 +208,23 @@ $ bin/busted -v -o gtest /kong-plugin/spec
   the same location where the tests run. It is in the Kong tree, excluded from the
   git repo, and accessible from the host to check logs when coding.
 
-## Testing
+## Environment Variables
 
-- run the tests from the vagrant box. Not from the host.
-- stop Kong before running the tests
-- clear any environment variables set before testing
-- `cd /kong && bin/busted` to run the tests. Check busted documentation for
-  additional commandline options.
+You can alter the behavior of the provision step by setting the following 
+environment variables:
 
-Eventually, to test Kong familiarize yourself with the 
-[Makefile Operations](https://github.com/Mashape/kong#makefile).
+| name            | description                                                               | default   |
+| --------------- | ------------------------------------------------------------------------- | --------- |
+| `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.10.0`  |
+| `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `1024`    |
+| `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
+| `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
+| `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |
+
+Use them when provisioning, e.g.:
+```shell
+$ KONG_VERSION=0.9.5 vagrant up
+```
 
 ## Known Issues
 
@@ -211,16 +239,16 @@ So please reprovision it and specify the proper version you want to work with
 version 0.9.2;
 
 ```shell
+# clone this repository
+$ git clone https://github.com/Mashape/kong-vagrant
+$ cd kong-vagrant/
+
 # clone the Kong repo and switch explicitly to the 0.9.2 version.
 # this will get the proper Kong source code for the version.
 $ git clone https://github.com/Mashape/kong
 $ cd kong
 $ git checkout 0.9.2
 $ cd ..
-
-# clone this repository
-$ git clone https://github.com/Mashape/kong-vagrant
-$ cd kong-vagrant/
 
 # start a box with a folder synced to your local Kong clone, and
 # specifically targetting 0.9.2, to get the required binary versions

--- a/README.md
+++ b/README.md
@@ -44,14 +44,15 @@ environment variables:
 
 | name            | description                                                               | default   |
 | --------------- | ------------------------------------------------------------------------- | --------- |
-| `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `../kong` |
 | `KONG_VERSION`  | the Kong version number to download and install at the provision step     | `0.10.0`  |
 | `KONG_VB_MEM`   | virtual machine memory (RAM) size *(in MB)*                               | `1024`    |
-| `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/plugin` folder | `../kong-plugin` |
+| `KONG_CASSANDRA`| the major Cassandra version to use, either `2` or `3`                     | `3`, or `2` for Kong versions `9.x` and older |
+| `KONG_PATH`     | the path to mount your local Kong source under the guest's `/kong` folder | `./kong`, `../kong`, or nothing. In this order. |
+| `KONG_PLUGIN_PATH` | the path to mount your local plugin source under the guest's `/kong-plugin` folder | `./kong-plugin`, `../kong-plugin`, or nothing. In this order. |
 
 Use them when provisioning, e.g.:
 ```shell
-$ KONG_VERSION=0.9.5 KONG_VB_MEM=2048 vagrant up
+$ KONG_VERSION=0.9.5 vagrant up
 ```
 
 ## Building and running Kong
@@ -169,10 +170,10 @@ cd /kong
 $ make dev
 
 # run the plugin tests from the Kong repo
-$ bin/busted /plugin/spec
+$ bin/busted /kong-plugin/spec
 
 # for more verbose output do
-$ bin/busted -v -o gtest /plugin/spec
+$ bin/busted -v -o gtest /kong-plugin/spec
 ```
 
 
@@ -199,26 +200,10 @@ Eventually, to test Kong familiarize yourself with the
 
 ## Known Issues
 
-### DNS failure
-
-If for some reason the Vagrant box doesn't resolve properly DNS names, please 
-execute the following comand on the host:
-
-```
-$ vagrant halt
-$ VBoxManage modifyvm "vagrant_kong" --natdnsproxy1 on
-```
-
-and then re-provision the image by running:
-
-```
-$ vagrant up --provision
-```
-
 ### Incompatible versions error
 
 When Kong starts it can give errors for incompatible versions. This happens for 
-example when depedencies have been updated. Eg. 0.9.2 required Openresty 
+example when dependencies have been updated. Eg. 0.9.2 required Openresty 
 1.9.15.1, whilst 0.9.5 requires 1.11.2.1. 
 
 So please reprovision it and specify the proper version you want to work with 
@@ -231,6 +216,7 @@ version 0.9.2;
 $ git clone https://github.com/Mashape/kong
 $ cd kong
 $ git checkout 0.9.2
+$ cd ..
 
 # clone this repository
 $ git clone https://github.com/Mashape/kong-vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,11 +15,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_PLUGIN_PATH"]
     plugin_source = ENV["KONG_PLUGIN_PATH"]
   else
-    # set default, if it doesn't exist, point to Kong itself
     plugin_source = "../kong-plugin"
-    if not File.directory?(plugin_source)
-      plugin_source = source
-    end
   end
 
   if ENV['KONG_VB_MEM']
@@ -41,8 +37,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "hashicorp/precise64"
 
-  config.vm.synced_folder source, "/kong"
-  config.vm.synced_folder plugin_source, "/plugin"
+  if File.directory?(source)
+    config.vm.synced_folder source, "/kong"
+  end
+  if File.directory?(plugin_source)
+    config.vm.synced_folder plugin_source, "/plugin"
+  end
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,14 +8,22 @@ Vagrant.require_version ">= 1.4.3"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   if ENV["KONG_PATH"]
     source = ENV["KONG_PATH"]
-  else
+  elsif File.directory?("./kong")
+    source = "./kong"
+  elsif File.directory?("../kong")
     source = "../kong"
+  else
+    source = ""
   end
 
   if ENV["KONG_PLUGIN_PATH"]
     plugin_source = ENV["KONG_PLUGIN_PATH"]
-  else
+  elsif File.directory?("./kong-plugin")
+    plugin_source = "./kong-plugin"
+  elsif File.directory?("../kong-plugin")
     plugin_source = "../kong-plugin"
+  else
+    plugin_source = ""
   end
 
   if ENV['KONG_VB_MEM']
@@ -30,6 +38,24 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     version = "0.10.0"
   end
 
+  if ENV["KONG_CASSANDRA"]
+    cversion = ENV["KONG_CASSANDRA"]
+    if not cversion == "2"
+      if not cversion == "3"
+        raise "KONG_CASSANDRA must be either 2 or 3"
+      end
+    end
+  else
+    # set a default, 3.x, or for Kong < 0.10 then 2.x
+    cversion = "3"
+    v = version.split('.')
+    if v[1].strip.to_i == 0
+      if v[2].strip.to_i < 10
+        cversion = "2"
+      end
+    end
+  end
+
   config.vm.provider :virtualbox do |vb|
    vb.name = "vagrant_kong"
    vb.memory = memory
@@ -37,16 +63,16 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   config.vm.box = "hashicorp/precise64"
 
-  if File.directory?(source)
+  if not source == ""
     config.vm.synced_folder source, "/kong"
   end
-  if File.directory?(plugin_source)
-    config.vm.synced_folder plugin_source, "/plugin"
+  if not plugin_source == ""
+    config.vm.synced_folder plugin_source, "/kong-plugin"
   end
 
   config.vm.network :forwarded_port, guest: 8000, host: 8000
   config.vm.network :forwarded_port, guest: 8001, host: 8001
   config.vm.network :forwarded_port, guest: 8443, host: 8443
 
-  config.vm.provision "shell", path: "provision.sh", :args => version
+  config.vm.provision "shell", path: "provision.sh", :args => [version, cversion]
 end

--- a/provision.sh
+++ b/provision.sh
@@ -2,10 +2,26 @@
 
 set -o errexit
 
-KONG_VERSION=$@
+KONG_VERSION=$1
+CASSANDRA_VERSION=$2
+if [ "$CASSANDRA_VERSION" = "2" ]; then
+   CASSANDRA_VERSION=2.2.8
+else
+   CASSANDRA_VERSION=3.0.9
+fi
 
 echo "Installing Kong version: $KONG_VERSION"
 
+# Installing other dependencies
+sudo apt-get install -y git curl make pkg-config unzip libpcre3-dev
+
+# Assign permissions to "vagrant" user
+sudo chown -R vagrant /usr/local
+
+
+####################
+# Install Postgres #
+####################
 # Install Postgres
 sudo apt-get update
 sudo apt-get install -y software-properties-common python-software-properties
@@ -31,44 +47,15 @@ CREATE DATABASE kong OWNER kong;
 CREATE DATABASE kong_tests OWNER kong;
 EOF
 
-# Install Kong
-echo Fetching and installing Kong...
-wget -q -O kong.deb https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
-sudo apt-get install -y netcat openssl libpcre3 dnsmasq procps perl
-sudo dpkg -i kong.deb
-rm kong.deb
-
-# Installing other dependencies
-sudo apt-get install -y git curl make pkg-config unzip libpcre3-dev
-
-# Assign permissions to "vagrant" user
-sudo chown -R vagrant /usr/local
-
-# Adjust PATH
-export PATH=$PATH:/usr/local/bin:/usr/local/openresty/bin
-
-# Adjust PATH for future ssh
-echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin" >> /home/vagrant/.bashrc
-
-# Adjust LUA_PATH to find the plugin dev setup
-echo "export LUA_PATH=\"/plugin/?.lua;/plugin/?/init.lua;;\"" >> /home/vagrant/.bashrc
-
+#################
+# install redis #
+#################
 sudo apt-get install redis-server
 sudo chown vagrant /var/log/redis/redis-server.log
 
-# Prepare path to lua libraries
-ln -sfn /usr/local /home/vagrant/.luarocks
-
-# Set higher ulimit
-sudo bash -c 'echo "fs.file-max = 65536" >> /etc/sysctl.conf'
-sudo sysctl -p
-sudo bash -c "cat >> /etc/security/limits.conf" << EOL
-* soft     nproc          65535
-* hard     nproc          65535
-* soft     nofile         65535
-* hard     nofile         65535
-EOL
-
+#####################
+# install Cassandra #
+######################
 # Install java runtime (Cassandra dependency)
 echo Fetching and installing java...
 sudo mkdir -p /usr/lib/jvm
@@ -82,7 +69,38 @@ echo Fetching and installing Cassandra...
 echo 'deb http://debian.datastax.com/community stable main' | sudo tee -a /etc/apt/sources.list.d/cassandra.sources.list
 wget -q -O - '$@' http://debian.datastax.com/debian/repo_key | sudo apt-key add -
 sudo apt-get update
-sudo apt-get install cassandra=2.2.8 -y --force-yes
+sudo apt-get install cassandra=$CASSANDRA_VERSION -y --force-yes
 sudo /etc/init.d/cassandra restart
+
+################
+# Install Kong #
+################
+echo Fetching and installing Kong...
+wget -q -O kong.deb https://github.com/Mashape/kong/releases/download/$KONG_VERSION/kong-$KONG_VERSION.precise_all.deb
+sudo apt-get install -y netcat openssl libpcre3 dnsmasq procps perl
+sudo dpkg -i kong.deb
+rm kong.deb
+
+# Adjust PATH
+export PATH=$PATH:/usr/local/bin:/usr/local/openresty/bin
+
+# Adjust PATH for future ssh
+echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin" >> /home/vagrant/.bashrc
+
+# Adjust LUA_PATH to find the plugin dev setup
+echo "export LUA_PATH=\"/kong-plugin/?.lua;/kong-plugin/?/init.lua;;\"" >> /home/vagrant/.bashrc
+
+# Prepare path to lua libraries
+ln -sfn /usr/local /home/vagrant/.luarocks
+
+# Set higher ulimit
+sudo bash -c 'echo "fs.file-max = 65536" >> /etc/sysctl.conf'
+sudo sysctl -p
+sudo bash -c "cat >> /etc/security/limits.conf" << EOL
+* soft     nproc          65535
+* hard     nproc          65535
+* soft     nofile         65535
+* hard     nofile         65535
+EOL
 
 echo "Successfully Installed Kong version: $KONG_VERSION"


### PR DESCRIPTION
The source repos are now completely optional, such that the Vagrant box can also be used as an all-in-1 test box, to quickly try Kong.

Cassandra 3.x is now default for 0.10 release, 2.x remains for 0.9 and below. With a setting to force a  version.

added default repo locations inside the vagrant repo. So its a cleaner throw-away install for basic testing.