### PR TITLE
Adding a missing closing block quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You should receive a JSON response:
       ...
     ]
   }
-}
+}```
 
 
 See the environments variables section below for defaults used and how to


### PR DESCRIPTION
Current documentation ends up with a text paragraph stuck in a code block.