### PR TITLE
add openresty nginx sbin to PATH

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -138,10 +138,10 @@ EOL
 #############
 
 # Adjust PATH for future ssh
-echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/usr/local/stapxx" >> /home/vagrant/.bashrc
+echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/usr/local/stapxx:/usr/local/openresty/nginx/sbin" >> /home/vagrant/.bashrc
 
 # do the same for root so we access to profiling tools
-echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/usr/local/stapxx" >> /root/.bashrc
+echo "export PATH=\$PATH:/usr/local/bin:/usr/local/openresty/bin:/opt/stap/bin:/usr/local/stapxx:/usr/local/openresty/nginx/sbin" >> /root/.bashrc
 
 # Adjust LUA_PATH to find the plugin dev setup
 echo "export LUA_PATH=\"/kong-plugin/?.lua;/kong-plugin/?/init.lua;;\"" >> /home/vagrant/.bashrc


### PR DESCRIPTION
new tests rely on calling the openresty nginx binary directly via
shell.